### PR TITLE
Update PHP-CS-Fixer and PHP

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
-FROM php:7.1.5-alpine
+FROM php:7.2.14-alpine
 
 MAINTAINER herloct <herloct@gmail.com>
 
-ENV PHP_CS_FIXER_VERSION=2.13.0
+ENV PHP_CS_FIXER_VERSION=2.14.0
 
 RUN curl -L https://github.com/FriendsOfPHP/PHP-CS-Fixer/releases/download/v$PHP_CS_FIXER_VERSION/php-cs-fixer.phar > /usr/local/bin/php-cs-fixer \
     && chmod +x /usr/local/bin/php-cs-fixer \


### PR DESCRIPTION
The lastest version of PHP-CS-Fixer is now 2.14.0. It also wouldn't hurt to start using PHP 7.2, since 7.1's support has ended already in December.